### PR TITLE
Add native .linear region file format support

### DIFF
--- a/patches/net/minecraft/server/MinecraftServer.java.patch
+++ b/patches/net/minecraft/server/MinecraftServer.java.patch
@@ -677,7 +677,7 @@
                  }
              }
          }
-@@ -633,8 +_,27 @@
+@@ -633,8 +_,28 @@
          try {
              this.storageSource.close();
          } catch (IOException ioexception) {
@@ -697,6 +697,7 @@
 +        // Spigot end
 +        // Paper start - move final shutdown items here
 +        Util.shutdownExecutors();
++        com.mohistmc.youer.region.LinearRegionFileFlusher.shutdown(); // Youer - Linear region format background flusher
 +        try {
 +            net.minecrell.terminalconsole.TerminalConsoleAppender.close(); // Paper - Use TerminalConsoleAppender
 +        } catch (final Exception ignored) {

--- a/patches/net/minecraft/world/level/chunk/storage/RegionFile.java.patch
+++ b/patches/net/minecraft/world/level/chunk/storage/RegionFile.java.patch
@@ -1,12 +1,13 @@
 --- a/net/minecraft/world/level/chunk/storage/RegionFile.java
 +++ b/net/minecraft/world/level/chunk/storage/RegionFile.java
-@@ -46,7 +_,22 @@
+@@ -46,8 +_,23 @@
      protected final RegionBitmap usedSectors = new RegionBitmap();
  
      public RegionFile(RegionStorageInfo p_326174_, Path p_196950_, Path p_196951_, boolean p_196952_) throws IOException {
 -        this(p_326174_, p_196950_, p_196951_, RegionFileVersion.getSelected(), p_196952_);
+-    }
 +        this(p_326174_, p_196950_, p_196951_, RegionFileVersion.getCompressionFormat(), p_196952_);
-     }
++    }
 +
 +    // Youer start - lightweight constructor for alternate region formats. Keeping those formats as RegionFile
 +    // subclasses preserves RegionFileStorage's vanilla field and method descriptors for mod/Mixin compatibility.
@@ -24,6 +25,7 @@
 +    // Youer end
  
      public RegionFile(RegionStorageInfo p_326221_, Path p_63633_, Path p_63634_, RegionFileVersion p_63635_, boolean p_63636_) throws IOException {
+         this.info = p_326221_;
 @@ -82,6 +_,14 @@
                      if (l != 0) {
                          int i1 = getSectorNumber(l);

--- a/patches/net/minecraft/world/level/chunk/storage/RegionFile.java.patch
+++ b/patches/net/minecraft/world/level/chunk/storage/RegionFile.java.patch
@@ -1,12 +1,27 @@
 --- a/net/minecraft/world/level/chunk/storage/RegionFile.java
 +++ b/net/minecraft/world/level/chunk/storage/RegionFile.java
-@@ -46,7 +_,7 @@
+@@ -46,7 +_,22 @@
      protected final RegionBitmap usedSectors = new RegionBitmap();
  
      public RegionFile(RegionStorageInfo p_326174_, Path p_196950_, Path p_196951_, boolean p_196952_) throws IOException {
 -        this(p_326174_, p_196950_, p_196951_, RegionFileVersion.getSelected(), p_196952_);
 +        this(p_326174_, p_196950_, p_196951_, RegionFileVersion.getCompressionFormat(), p_196952_);
      }
++
++    // Youer start - lightweight constructor for alternate region formats. Keeping those formats as RegionFile
++    // subclasses preserves RegionFileStorage's vanilla field and method descriptors for mod/Mixin compatibility.
++    protected RegionFile(RegionStorageInfo info, Path path, Path externalFileDir) {
++        this.info = info;
++        this.path = path;
++        this.externalFileDir = externalFileDir;
++        this.version = RegionFileVersion.getCompressionFormat();
++        this.file = null;
++        this.offsets = this.header.asIntBuffer();
++        this.offsets.limit(SECTOR_INTS);
++        this.header.position(4096);
++        this.timestamps = this.header.asIntBuffer();
++    }
++    // Youer end
  
      public RegionFile(RegionStorageInfo p_326221_, Path p_63633_, Path p_63634_, RegionFileVersion p_63635_, boolean p_63636_) throws IOException {
 @@ -82,6 +_,14 @@

--- a/patches/net/minecraft/world/level/chunk/storage/RegionFileStorage.java.patch
+++ b/patches/net/minecraft/world/level/chunk/storage/RegionFileStorage.java.patch
@@ -1,11 +1,77 @@
 --- a/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
 +++ b/net/minecraft/world/level/chunk/storage/RegionFileStorage.java
-@@ -34,7 +_,7 @@
+@@ -3,7 +_,9 @@
++import com.mohistmc.youer.region.LinearRegionFile;
+ import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
+ import java.io.DataInputStream;
+ import java.io.DataOutputStream;
+ import java.io.IOException;
++import java.nio.file.Files;
+ import java.nio.file.Path;
+ import javax.annotation.Nullable;
+ import net.minecraft.FileUtil;
+@@ -28,23 +_,61 @@
+         this.info = p_326161_;
+     }
+ 
++    // Youer - recomputed on demand (only runs on a cache miss, not per read/write) rather than tracked as a
++    // running counter, since a cached LinearRegionFile's memory usage changes as chunks are written after
++    // caching - a counter updated only at insert/evict time would go stale.
++    private long currentEstimatedMemoryUsageBytes() {
++        long total = 0L;
++        for (RegionFile regionfile : this.regionCache.values()) {
++            if (regionfile instanceof LinearRegionFile linearRegionFile) {
++                total += linearRegionFile.estimatedMemoryUsageBytes();
++            }
++        }
++        return total;
++    }
++
++    // Youer start - Linear region format - choose RegionFile vs LinearRegionFile per-region based on what
++    // actually exists on disk first, so an already-converted-to-Linear world is always read correctly
++    // regardless of config, and a partial conversion degrades gracefully instead of orphaning files.
++    // The configured default format is only consulted for a brand-new region.
++    // Keep this method's original RegionFile return type: many mods target its exact bytecode descriptor.
+     private RegionFile getRegionFile(ChunkPos p_63712_) throws IOException {
+         long i = ChunkPos.asLong(p_63712_.getRegionX(), p_63712_.getRegionZ());
+         RegionFile regionfile = this.regionCache.getAndMoveToFirst(i);
          if (regionfile != null) {
              return regionfile;
          } else {
 -            if (this.regionCache.size() >= 256) {
-+            if (this.regionCache.size() >= io.papermc.paper.configuration.GlobalConfiguration.get().misc.regionFileCacheSize) { // Paper - Sanitise RegionFileCache and make configurable
++            // Youer start - also evict while over the Linear-specific memory budget (no-op for pure-Anvil caches)
++            long memoryBudgetBytes = (long) io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.linearRegionCacheMemoryBudgetMb * 1024L * 1024L;
++            while ((this.regionCache.size() >= io.papermc.paper.configuration.GlobalConfiguration.get().misc.regionFileCacheSize // Paper - Sanitise RegionFileCache and make configurable
++                    || this.currentEstimatedMemoryUsageBytes() > memoryBudgetBytes)
++                    && !this.regionCache.isEmpty()) {
                  this.regionCache.removeLast().close();
              }
++            // Youer end
  
+             FileUtil.createDirectoriesSafe(this.folder);
+-            Path path = this.folder.resolve("r." + p_63712_.getRegionX() + "." + p_63712_.getRegionZ() + ".mca");
+-            RegionFile regionfile1 = new RegionFile(this.info, path, this.folder, this.sync);
++            int regionX = p_63712_.getRegionX();
++            int regionZ = p_63712_.getRegionZ();
++            Path linearPath = this.folder.resolve("r." + regionX + "." + regionZ + LinearRegionFile.LINEAR_EXTENSION);
++            Path anvilPath = this.folder.resolve("r." + regionX + "." + regionZ + ANVIL_EXTENSION);
++
++            RegionFile regionfile1;
++            if (Files.exists(linearPath)) {
++                regionfile1 = new LinearRegionFile(this.info, linearPath, this.folder, this.sync);
++            } else if (Files.exists(anvilPath)) {
++                regionfile1 = new RegionFile(this.info, anvilPath, this.folder, this.sync);
++            } else {
++                regionfile1 = switch (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.regionFileFormat) {
++                    case LINEAR -> new LinearRegionFile(this.info, linearPath, this.folder, this.sync);
++                    case ANVIL -> new RegionFile(this.info, anvilPath, this.folder, this.sync);
++                };
++            }
+             this.regionCache.putAndMoveToFirst(i, regionfile1);
+             return regionfile1;
+         }
+     }
++    // Youer end - Linear region format
+ 
+     @Nullable
+     public CompoundTag read(ChunkPos p_63707_) throws IOException {

--- a/src/main/java/com/mohistmc/youer/region/LinearRegionFile.java
+++ b/src/main/java/com/mohistmc/youer/region/LinearRegionFile.java
@@ -1,0 +1,436 @@
+package com.mohistmc.youer.region;
+
+import com.github.luben.zstd.ZstdInputStream;
+import com.github.luben.zstd.ZstdOutputStream;
+import com.mojang.logging.LogUtils;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import javax.annotation.Nullable;
+import net.minecraft.FileUtil;
+import net.minecraft.Util;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.storage.RegionFile;
+import net.minecraft.world.level.chunk.storage.RegionStorageInfo;
+import org.slf4j.Logger;
+
+// Linear region format (github.com/xymb-endcrystalme/LinearRegionFileFormatTools), v1 spec.
+// Unlike Anvil, an entire 32x32 region is compressed as a single zstd stream, so there is no in-place
+// partial update: writes replace an in-memory slot. The background flusher briefly snapshots those
+// immutable byte arrays, then serializes and compresses the WHOLE snapshot without holding this
+// region's monitor, so reads and later writes do not wait for compression or disk I/O.
+public class LinearRegionFile extends RegionFile {
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    public static final String LINEAR_EXTENSION = ".linear";
+
+    private static final long SIGNATURE = 0xc3ff13183cca9d9aL;
+    private static final int SUPPORTED_VERSION = 1;
+    private static final int ENTRY_COUNT = 1024; // 32 x 32 chunks per region
+    // signature(8) + version(1) + newest_timestamp(8) + compression_level(1) + chunk_count(2) + body_length(4) + reserved(8)
+    private static final int OUTER_HEADER_LENGTH = 32;
+    private static final int INNER_HEADER_LENGTH = ENTRY_COUNT * 8; // (size:uint32, timestamp:uint32) per slot
+    private static final byte[] RESERVED = new byte[8];
+
+    private final RegionStorageInfo info;
+    private final Path path;
+    private final Path folder;
+    private final boolean sync;
+
+    private final byte[][] chunks = new byte[ENTRY_COUNT][];
+    private final int[] timestamps = new int[ENTRY_COUNT];
+    private long currentGeneration;
+    private long persistedGeneration;
+    private long completedFlushAttempts;
+    private IOException lastFlushFailure;
+    private boolean closing;
+    private boolean closed;
+
+    public LinearRegionFile(RegionStorageInfo info, Path path, Path folder, boolean sync) throws IOException {
+        super(info, path, folder);
+        this.info = info;
+        this.path = path;
+        this.folder = folder;
+        this.sync = sync;
+        if (Files.isRegularFile(path)) {
+            this.load();
+        }
+    }
+
+    private static int getIndex(ChunkPos pos) {
+        return pos.getRegionLocalX() + pos.getRegionLocalZ() * 32;
+    }
+
+    private static int getTimestamp() {
+        return (int) (Util.getEpochMillis() / 1000L);
+    }
+
+    private void load() throws IOException {
+        try (DataInputStream in = new DataInputStream(new BufferedInputStream(Files.newInputStream(this.path)))) {
+            long signature = in.readLong();
+            if (signature != SIGNATURE) {
+                LOGGER.error("Linear region file {} has an invalid signature (0x{}); treating it as empty so its chunks will be regenerated", this.path, Long.toHexString(signature));
+                return;
+            }
+
+            int version = in.readUnsignedByte();
+            if (version != SUPPORTED_VERSION) {
+                LOGGER.error("Linear region file {} has unsupported version {} (only version {} is supported); treating it as empty so its chunks will be regenerated", this.path, version, SUPPORTED_VERSION);
+                return;
+            }
+
+            in.readLong(); // newest_timestamp - informational only, recomputed from per-chunk timestamps on write
+            in.readUnsignedByte(); // compression_level - informational only, zstd frames are self-describing
+            int declaredChunkCount = in.readUnsignedShort();
+            int bodyLength = in.readInt();
+            in.readFully(new byte[8]); // reserved/hash - not verified for v1 compatibility, per spec
+
+            if (bodyLength < 0) {
+                LOGGER.error("Linear region file {} declares a negative body length {}; treating it as empty so its chunks will be regenerated", this.path, bodyLength);
+                return;
+            }
+
+            byte[] compressedBody = in.readNBytes(bodyLength);
+            if (compressedBody.length != bodyLength) {
+                LOGGER.error("Linear region file {} is truncated: expected {} compressed body bytes but only read {}; treating it as empty so its chunks will be regenerated", this.path, bodyLength, compressedBody.length);
+                return;
+            }
+
+            long footerSignature = in.readLong();
+            if (footerSignature != SIGNATURE) {
+                LOGGER.error("Linear region file {} has an invalid footer signature (0x{}); it is likely truncated or corrupt, treating it as empty so its chunks will be regenerated", this.path, Long.toHexString(footerSignature));
+                return;
+            }
+
+            byte[] decompressed;
+            try (DataInputStream zin = new DataInputStream(new ZstdInputStream(new ByteArrayInputStream(compressedBody)))) {
+                decompressed = zin.readAllBytes();
+            }
+
+            if (decompressed.length < INNER_HEADER_LENGTH) {
+                LOGGER.error("Linear region file {} decompressed body ({} bytes) is smaller than the inner header ({} bytes); treating it as empty so its chunks will be regenerated", this.path, decompressed.length, INNER_HEADER_LENGTH);
+                return;
+            }
+
+            int[] sizes = new int[ENTRY_COUNT];
+            try (DataInputStream headerIn = new DataInputStream(new ByteArrayInputStream(decompressed, 0, INNER_HEADER_LENGTH))) {
+                for (int i = 0; i < ENTRY_COUNT; i++) {
+                    sizes[i] = headerIn.readInt();
+                    this.timestamps[i] = headerIn.readInt();
+                }
+            }
+
+            int offset = INNER_HEADER_LENGTH;
+            int loaded = 0;
+            for (int i = 0; i < ENTRY_COUNT; i++) {
+                int size = sizes[i];
+                if (size == 0) {
+                    continue;
+                }
+                if (size < 0 || offset + size > decompressed.length) {
+                    LOGGER.error(
+                        "Linear region file {} chunk slot {} declares an out-of-bounds size {} (offset {}, decompressed body length {}); the remaining chunk slot(s) in this file will be dropped and regenerated",
+                        this.path, i, size, offset, decompressed.length
+                    );
+                    break;
+                }
+                this.chunks[i] = Arrays.copyOfRange(decompressed, offset, offset + size);
+                offset += size;
+                loaded++;
+            }
+
+            if (loaded != declaredChunkCount) {
+                LOGGER.debug("Linear region file {} header chunk_count {} does not match {} chunk(s) actually parsed", this.path, declaredChunkCount, loaded);
+            }
+        } catch (EOFException eofexception) {
+            LOGGER.error("Linear region file {} is truncated (unexpected end of file while reading header); treating it as empty so its chunks will be regenerated: {}", this.path, eofexception.toString());
+            Arrays.fill(this.chunks, null);
+            Arrays.fill(this.timestamps, 0);
+        } catch (RuntimeException runtimeexception) {
+            // com.github.luben.zstd throws unchecked exceptions on a malformed/corrupt zstd frame
+            LOGGER.error("Linear region file {} could not be decoded, treating it as empty so its chunks will be regenerated: {}", this.path, runtimeexception.toString(), runtimeexception);
+            Arrays.fill(this.chunks, null);
+            Arrays.fill(this.timestamps, 0);
+        }
+    }
+
+    @Override
+    public Path getPath() {
+        return this.path;
+    }
+
+    @Nullable
+    @Override
+    public synchronized DataInputStream getChunkDataInputStream(ChunkPos pos) throws IOException {
+        this.ensureOpen();
+        byte[] data = this.chunks[getIndex(pos)];
+        return data == null ? null : new DataInputStream(new ByteArrayInputStream(data));
+    }
+
+    @Override
+    public synchronized DataOutputStream getChunkDataOutputStream(ChunkPos pos) throws IOException {
+        this.ensureWritable();
+        return new DataOutputStream(new ChunkBuffer(pos));
+    }
+
+    @Override
+    public synchronized boolean hasChunk(ChunkPos pos) {
+        return this.chunks[getIndex(pos)] != null;
+    }
+
+    @Override
+    public synchronized boolean doesChunkExist(ChunkPos pos) {
+        // Unlike Anvil's sector-offset bookkeeping, there is nothing further to sanity-check beyond "did this
+        // slot load successfully" once the region file itself has been parsed - equivalent to hasChunk() here.
+        return this.hasChunk(pos);
+    }
+
+    // Sum of currently-held decompressed chunk bytes, used by RegionFileStorage's memory-budget eviction
+    public synchronized long estimatedMemoryUsageBytes() {
+        long total = 0L;
+        for (byte[] chunk : this.chunks) {
+            if (chunk != null) {
+                total += chunk.length;
+            }
+        }
+        return total;
+    }
+
+    @Override
+    public synchronized void clear(ChunkPos pos) throws IOException {
+        this.ensureWritable();
+        int index = getIndex(pos);
+        if (this.chunks[index] != null) {
+            this.chunks[index] = null;
+            this.timestamps[index] = getTimestamp();
+            this.currentGeneration++;
+            LinearRegionFileFlusher.scheduleFlush(this);
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        final long targetGeneration;
+        synchronized (this) {
+            this.ensureOpen();
+            targetGeneration = this.currentGeneration;
+        }
+        LinearRegionFileFlusher.flushAndWait(this, targetGeneration);
+    }
+
+    @Override
+    public void close() throws IOException {
+        final long targetGeneration;
+        synchronized (this) {
+            if (this.closed) {
+                return;
+            }
+            this.closing = true;
+            targetGeneration = this.currentGeneration;
+        }
+
+        try {
+            LinearRegionFileFlusher.flushAndWait(this, targetGeneration);
+            synchronized (this) {
+                this.closed = true;
+            }
+            LinearRegionFileFlusher.forget(this);
+        } catch (IOException ioexception) {
+            synchronized (this) {
+                this.closing = false;
+            }
+            throw ioexception;
+        }
+    }
+
+    // Overridable seam so tests can supply a fixed level without a running server's GlobalConfiguration
+    protected int getCompressionLevel() {
+        return io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.linearCompressionLevel;
+    }
+
+    // Overridable seam so tests can supply a fixed thread count without a running server's GlobalConfiguration
+    protected int getCompressionThreads() {
+        return io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.linearCompressionThreads;
+    }
+
+    synchronized long currentGeneration() {
+        return this.currentGeneration;
+    }
+
+    synchronized boolean isPersisted(long generation) {
+        return this.persistedGeneration >= generation;
+    }
+
+    synchronized long completedFlushAttempts() {
+        return this.completedFlushAttempts;
+    }
+
+    synchronized IOException awaitFlushProgress(long targetGeneration, long observedAttempt) throws InterruptedException {
+        while (this.persistedGeneration < targetGeneration && this.completedFlushAttempts == observedAttempt) {
+            this.wait();
+        }
+        return this.completedFlushAttempts == observedAttempt ? null : this.lastFlushFailure;
+    }
+
+    synchronized FlushSnapshot createFlushSnapshot() {
+        if (this.persistedGeneration >= this.currentGeneration) {
+            return null;
+        }
+        return new FlushSnapshot(this.chunks.clone(), this.timestamps.clone(), this.currentGeneration);
+    }
+
+    synchronized boolean completeFlush(FlushSnapshot snapshot, IOException failure) {
+        if (failure == null) {
+            this.persistedGeneration = Math.max(this.persistedGeneration, snapshot.generation());
+        }
+        this.lastFlushFailure = failure;
+        this.completedFlushAttempts++;
+        this.notifyAll();
+        return this.persistedGeneration < this.currentGeneration;
+    }
+
+    void writeSnapshot(FlushSnapshot snapshot) throws IOException {
+        int chunkCount = 0;
+        for (byte[] chunk : snapshot.chunks()) {
+            if (chunk != null) {
+                chunkCount++;
+            }
+        }
+
+        int level = this.getCompressionLevel();
+        int workers = this.getCompressionThreads(); // zstd's own internal multi-threaded compression
+        int newestTimestamp = 0;
+        for (int timestamp : snapshot.timestamps()) {
+            newestTimestamp = Math.max(newestTimestamp, timestamp);
+        }
+
+        FileUtil.createDirectoriesSafe(this.folder);
+        Path tmp = Files.createTempFile(this.folder, "linear-", ".tmp");
+        try {
+            try (FileChannel channel = FileChannel.open(tmp, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                channel.position(OUTER_HEADER_LENGTH);
+                OutputStream channelOutput = Channels.newOutputStream(channel);
+                try (ZstdOutputStream zout = new ZstdOutputStream(new NonClosingOutputStream(channelOutput), level)) {
+                    if (workers > 0) {
+                        zout.setWorkers(workers);
+                    }
+                    DataOutputStream bodyOut = new DataOutputStream(zout);
+                    for (int i = 0; i < ENTRY_COUNT; i++) {
+                        byte[] chunk = snapshot.chunks()[i];
+                        bodyOut.writeInt(chunk == null ? 0 : chunk.length);
+                        bodyOut.writeInt(snapshot.timestamps()[i]);
+                    }
+                    for (byte[] chunk : snapshot.chunks()) {
+                        if (chunk != null) {
+                            bodyOut.write(chunk);
+                        }
+                    }
+                }
+
+                long compressedLength = channel.position() - OUTER_HEADER_LENGTH;
+                if (compressedLength > Integer.MAX_VALUE) {
+                    throw new IOException("Linear region compressed body exceeds the v1 format limit: " + compressedLength + " bytes");
+                }
+
+                ByteBuffer footer = ByteBuffer.allocate(Long.BYTES).putLong(SIGNATURE);
+                footer.flip();
+                writeFully(channel, footer);
+
+                ByteBuffer header = ByteBuffer.allocate(OUTER_HEADER_LENGTH);
+                header.putLong(SIGNATURE);
+                header.put((byte) SUPPORTED_VERSION);
+                header.putLong(newestTimestamp);
+                header.put((byte) level);
+                header.putShort((short) chunkCount);
+                header.putInt((int) compressedLength);
+                header.put(RESERVED);
+                header.flip();
+                channel.position(0L);
+                writeFully(channel, header);
+                if (this.sync) {
+                    channel.force(true);
+                }
+            }
+
+            try {
+                Files.move(tmp, this.path, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException ignored) {
+                Files.move(tmp, this.path, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException ioexception) {
+            Files.deleteIfExists(tmp);
+            throw ioexception;
+        } catch (RuntimeException runtimeexception) {
+            Files.deleteIfExists(tmp);
+            throw new IOException("Failed to encode linear region file " + this.path, runtimeexception);
+        }
+    }
+
+    private static void writeFully(FileChannel channel, ByteBuffer buffer) throws IOException {
+        while (buffer.hasRemaining()) {
+            channel.write(buffer);
+        }
+    }
+
+    private void ensureOpen() throws IOException {
+        if (this.closed) {
+            throw new IOException("Linear region file is closed: " + this.path);
+        }
+    }
+
+    private void ensureWritable() throws IOException {
+        this.ensureOpen();
+        if (this.closing) {
+            throw new IOException("Linear region file is closing: " + this.path);
+        }
+    }
+
+    private class ChunkBuffer extends ByteArrayOutputStream {
+        private final ChunkPos pos;
+
+        ChunkBuffer(ChunkPos pos) {
+            super(8096);
+            this.pos = pos;
+        }
+
+        @Override
+        public void close() throws IOException {
+            synchronized (LinearRegionFile.this) {
+                LinearRegionFile.this.ensureWritable();
+                int index = getIndex(this.pos);
+                LinearRegionFile.this.chunks[index] = this.toByteArray();
+                LinearRegionFile.this.timestamps[index] = getTimestamp();
+                LinearRegionFile.this.currentGeneration++;
+                LinearRegionFileFlusher.scheduleFlush(LinearRegionFile.this);
+            }
+        }
+    }
+
+    static record FlushSnapshot(byte[][] chunks, int[] timestamps, long generation) {}
+
+    private static final class NonClosingOutputStream extends FilterOutputStream {
+        private NonClosingOutputStream(OutputStream output) {
+            super(output);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.flush();
+        }
+    }
+}

--- a/src/main/java/com/mohistmc/youer/region/LinearRegionFileFlusher.java
+++ b/src/main/java/com/mohistmc/youer/region/LinearRegionFileFlusher.java
@@ -1,0 +1,274 @@
+package com.mohistmc.youer.region;
+
+import com.mojang.logging.LogUtils;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+
+// Background flusher for the Linear region format. Writes/clears mark a LinearRegionFile dirty and
+// enqueue it here instead of blocking the calling IOWorker thread with compression or disk I/O.
+// PENDING coalesces repeated writes and IN_FLIGHT guarantees that only one immutable snapshot of a
+// particular region is written at once. The fixed worker pool still allows different regions to be
+// processed in parallel.
+public final class LinearRegionFileFlusher {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final Object LIFECYCLE_LOCK = new Object();
+
+    private static final Set<LinearRegionFile> PENDING = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private static final Set<LinearRegionFile> IN_FLIGHT = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private static final Set<LinearRegionFile> KNOWN = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private static ScheduledExecutorService scheduler;
+    private static ExecutorService workers;
+    private static boolean shuttingDown;
+
+    private LinearRegionFileFlusher() {}
+
+    public static void scheduleFlush(LinearRegionFile regionFile) {
+        KNOWN.add(regionFile);
+        boolean flushDuringShutdown;
+        synchronized (LIFECYCLE_LOCK) {
+            flushDuringShutdown = shuttingDown;
+            if (!flushDuringShutdown) {
+                ensureStartedLocked();
+            }
+        }
+        PENDING.add(regionFile);
+        if (flushDuringShutdown) {
+            try {
+                flushAndWait(regionFile, regionFile.currentGeneration());
+            } catch (IOException ioexception) {
+                LOGGER.error("Failed to flush linear region file {} during shutdown", regionFile.getPath(), ioexception);
+            }
+        }
+    }
+
+    public static void flushAndWait(LinearRegionFile regionFile, long targetGeneration) throws IOException {
+        if (regionFile.isPersisted(targetGeneration)) {
+            return;
+        }
+
+        KNOWN.add(regionFile);
+        final boolean flushDirectly;
+        synchronized (LIFECYCLE_LOCK) {
+            if (workers == null || workers.isShutdown()) {
+                if (shuttingDown) {
+                    flushDirectly = true;
+                } else {
+                    ensureStartedLocked();
+                    flushDirectly = false;
+                }
+            } else {
+                flushDirectly = false;
+            }
+        }
+        if (flushDirectly) {
+            flushDirect(regionFile, targetGeneration);
+            return;
+        }
+
+        PENDING.add(regionFile);
+        while (!regionFile.isPersisted(targetGeneration)) {
+            long observedAttempt = regionFile.completedFlushAttempts();
+            if (!submit(regionFile)) {
+                // The executor may have entered shutdown after the lifecycle check. The direct
+                // path uses the same IN_FLIGHT slot, so it cannot race an already-running write.
+                flushDirect(regionFile, targetGeneration);
+                return;
+            }
+            final IOException failure;
+            try {
+                failure = regionFile.awaitFlushProgress(targetGeneration, observedAttempt);
+            } catch (InterruptedException interruptedexception) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while flushing linear region file " + regionFile.getPath(), interruptedexception);
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+
+    public static void forget(LinearRegionFile regionFile) {
+        PENDING.remove(regionFile);
+        KNOWN.remove(regionFile);
+    }
+
+    private static void ensureStartedLocked() {
+        if (scheduler != null) {
+            return;
+        }
+        int threads = Math.max(1, io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.linearFlushThreads);
+        int intervalSeconds = Math.max(1, io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.linearFlushIntervalSeconds);
+
+        AtomicInteger workerId = new AtomicInteger();
+        workers = Executors.newFixedThreadPool(threads, runnable -> {
+            Thread thread = new Thread(runnable, "Linear Region Flusher #" + workerId.getAndIncrement());
+            thread.setDaemon(false); // must not be daemon: killing mid-write/mid-rename can corrupt a region file
+            thread.setUncaughtExceptionHandler((t, e) -> LOGGER.error("Uncaught exception in {}", t.getName(), e));
+            return thread;
+        });
+
+        ScheduledExecutorService newScheduler = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "Linear Region Flusher Scheduler");
+            thread.setDaemon(false);
+            thread.setUncaughtExceptionHandler((t, e) -> LOGGER.error("Uncaught exception in {}", t.getName(), e));
+            return thread;
+        });
+        newScheduler.scheduleAtFixedRate(LinearRegionFileFlusher::drain, intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
+        scheduler = newScheduler;
+    }
+
+    private static void drain() {
+        if (PENDING.isEmpty()) {
+            return;
+        }
+
+        Iterator<LinearRegionFile> iterator = PENDING.iterator();
+        while (iterator.hasNext()) {
+            LinearRegionFile regionFile = iterator.next();
+            submit(regionFile);
+        }
+    }
+
+    private static boolean submit(LinearRegionFile regionFile) {
+        if (!IN_FLIGHT.add(regionFile)) {
+            return true;
+        }
+
+        final ExecutorService pool;
+        synchronized (LIFECYCLE_LOCK) {
+            pool = workers;
+        }
+        if (pool == null || pool.isShutdown()) {
+            IN_FLIGHT.remove(regionFile);
+            return false;
+        }
+
+        PENDING.remove(regionFile);
+        try {
+            pool.execute(() -> flushOne(regionFile));
+            return true;
+        } catch (RejectedExecutionException rejectedexecutionexception) {
+            IN_FLIGHT.remove(regionFile);
+            PENDING.add(regionFile);
+            return false;
+        }
+    }
+
+    private static void flushOne(LinearRegionFile regionFile) {
+        LinearRegionFile.FlushSnapshot snapshot = regionFile.createFlushSnapshot();
+        if (snapshot == null) {
+            IN_FLIGHT.remove(regionFile);
+            return;
+        }
+
+        IOException failure = null;
+        try {
+            regionFile.writeSnapshot(snapshot);
+        } catch (IOException ioexception) {
+            failure = ioexception;
+            LOGGER.error("Failed to background-flush linear region file {}", regionFile.getPath(), ioexception);
+        } catch (RuntimeException runtimeexception) {
+            failure = new IOException("Failed to flush linear region file " + regionFile.getPath(), runtimeexception);
+            LOGGER.error("Failed to background-flush linear region file {}", regionFile.getPath(), runtimeexception);
+        } finally {
+            // Release the per-region execution slot before waking explicit flush waiters. A waiter
+            // can then immediately submit the next generation instead of waiting for the timer.
+            IN_FLIGHT.remove(regionFile);
+            if (regionFile.completeFlush(snapshot, failure)) {
+                PENDING.add(regionFile);
+            }
+        }
+    }
+
+    private static void flushDirect(LinearRegionFile regionFile, long targetGeneration) throws IOException {
+        while (!regionFile.isPersisted(targetGeneration)) {
+            long observedAttempt = regionFile.completedFlushAttempts();
+            if (!IN_FLIGHT.add(regionFile)) {
+                final IOException failure;
+                try {
+                    failure = regionFile.awaitFlushProgress(targetGeneration, observedAttempt);
+                } catch (InterruptedException interruptedexception) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while flushing linear region file " + regionFile.getPath(), interruptedexception);
+                }
+                if (failure != null) {
+                    throw failure;
+                }
+                continue;
+            }
+
+            LinearRegionFile.FlushSnapshot snapshot = regionFile.createFlushSnapshot();
+            if (snapshot == null) {
+                IN_FLIGHT.remove(regionFile);
+                return;
+            }
+            IOException failure = null;
+            try {
+                regionFile.writeSnapshot(snapshot);
+            } catch (IOException ioexception) {
+                failure = ioexception;
+            } catch (RuntimeException runtimeexception) {
+                failure = new IOException("Failed to flush linear region file " + regionFile.getPath(), runtimeexception);
+            } finally {
+                IN_FLIGHT.remove(regionFile);
+                if (regionFile.completeFlush(snapshot, failure)) {
+                    PENDING.add(regionFile);
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+
+    // Drains any remaining dirty regions and waits for in-flight flushes before shutdown, so the JVM
+    // never exits (and no thread is killed) mid-compress/mid-rename of a region file.
+    public static void shutdown() {
+        ScheduledExecutorService currentScheduler;
+        ExecutorService currentWorkers;
+        synchronized (LIFECYCLE_LOCK) {
+            shuttingDown = true;
+            currentScheduler = scheduler;
+            currentWorkers = workers;
+        }
+
+        if (currentScheduler != null) {
+            currentScheduler.shutdown();
+        }
+
+        for (LinearRegionFile regionFile : KNOWN.toArray(LinearRegionFile[]::new)) {
+            try {
+                flushAndWait(regionFile, regionFile.currentGeneration());
+            } catch (IOException ioexception) {
+                LOGGER.error("Failed to flush linear region file {} during shutdown", regionFile.getPath(), ioexception);
+            }
+        }
+
+        if (currentWorkers == null) {
+            return;
+        }
+        currentWorkers.shutdown();
+        try {
+            if (!currentWorkers.awaitTermination(60, TimeUnit.SECONDS)) {
+                LOGGER.error("Linear region flusher did not shut down in time; some pending writes may not have been saved");
+            }
+        } catch (InterruptedException interruptedexception) {
+            Thread.currentThread().interrupt();
+        }
+
+        synchronized (LIFECYCLE_LOCK) {
+            scheduler = null;
+            workers = null;
+        }
+    }
+}

--- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
@@ -179,6 +179,50 @@ public class GlobalConfiguration extends ConfigurationPart {
         public CompressionFormat compressionFormat = CompressionFormat.ZLIB;
         @Comment("Only checks an item's amount and type instead of its full data during inventory desync checks.")
         public boolean simplifyRemoteItemMatching = false;
+        @Comment(
+            "Controls which on-disk region file format is used for saving/loading chunks. ANVIL is the vanilla " +
+            ".mca format. LINEAR uses the third-party .linear format (see " +
+            "github.com/xymb-endcrystalme/LinearRegionFileFormatTools), which compresses an entire 32x32 region as " +
+            "a single stream instead of per-chunk, typically giving much better compression ratios at the cost of " +
+            "needing to rewrite/recompress the whole region file on every flush. Existing .linear or .mca files " +
+            "found on disk are always honored regardless of this setting - it only controls the format used for " +
+            "brand-new regions. Switching this after regions already exist does not retroactively convert them."
+        )
+        public RegionFileFormat regionFileFormat = RegionFileFormat.ANVIL;
+        @Comment(
+            "The zstd compression level used when writing .linear region files (1-22, higher = smaller files but " +
+            "more CPU). Defaults to a fast level since Linear recompresses the entire region (not just the changed " +
+            "chunk) on every flush; raise it to 6-9+ if you want smaller files on disk and can afford the extra CPU."
+        )
+        public int linearCompressionLevel = 3;
+        @Comment(
+            "Number of background worker threads used to compress/write dirty .linear regions asynchronously, " +
+            "instead of blocking chunk I/O while a region is recompressed and saved. Different regions may be " +
+            "processed in parallel, but the same region is never flushed by more than one worker at a time. " +
+            "Changes require a restart."
+        )
+        @Constraints.Min(1)
+        public int linearFlushThreads = 2;
+        @Comment("How often, in seconds, the background .linear flusher checks for dirty regions to save.")
+        @Constraints.Min(1)
+        public int linearFlushIntervalSeconds = 5;
+        @Comment(
+            "Number of internal worker threads zstd itself uses to compress a single .linear region, via zstd's " +
+            "own multi-threaded compression API. This is separate from and safe alongside linear-flush-threads - " +
+            "it parallelizes work within one compression job rather than across regions, entirely inside zstd's " +
+            "own library, with no Minecraft-side concurrency involved. 0 disables this (default, unchanged " +
+            "behavior); try 2-4 if compression is still a CPU bottleneck after lowering linear-compression-level."
+        )
+        public int linearCompressionThreads = 0;
+        @Comment(
+            "Maximum estimated memory, in megabytes, that cached .linear regions' decompressed chunk data may use " +
+            "at once. Unlike Anvil, Linear has to hold a whole region's chunks decompressed in memory while it's " +
+            "cached (inherent to the format, not specific to this implementation) - this bounds that growth " +
+            "independently of region-file-cache-size, evicting the least-recently-used region early if needed. " +
+            "Has no effect on Anvil regions."
+        )
+        @Constraints.Min(1)
+        public int linearRegionCacheMemoryBudgetMb = 512;
 
         public enum CompressionFormat {
             GZIP,
@@ -186,6 +230,11 @@ public class GlobalConfiguration extends ConfigurationPart {
             LZ4,
             ZSTD,
             NONE
+        }
+
+        public enum RegionFileFormat {
+            ANVIL,
+            LINEAR
         }
     }
 


### PR DESCRIPTION
Fixes #491

The root problem in #491 is that LinearReader hooks in via Mixin `@Overwrite` on top of an already-patched `RegionFileStorage`, and every chunk read/write for the whole world was serialized through one thread anyway, so the mod never really got to show its own concurrency support. Rather than keep fighting that from the outside, this builds `.linear` support straight into Youer's own region storage, the same way LinearPurpur and Leaves already do it for their forks.

`RegionFileStorage` now looks at what's actually on disk before deciding how to open a region: if there's already a `.linear` file it uses that, if there's a `.mca` it uses that, and only falls back to config for a region that doesn't exist yet. So if you've already converted your world with LinearReader, it just keeps working, no reconversion, and you can drop the mod entirely.

Normal chunk writes are memory-only and coalesced. When a dirty Linear region is flushed, Youer takes a short immutable snapshot under the region lock, then serializes and zstd-compresses the entire 32x32 region outside that lock. This keeps caller latency closer to Anvil's per-chunk write behavior while preserving the Linear v1 whole-region format. Explicit `flush()`, save-all, eviction/close, and server shutdown remain strict durability barriers and wait for their target generation to reach disk.

The flusher defaults to two workers and is configurable. Different region files can compress/write in parallel, while an in-flight guard guarantees the same region file is never flushed concurrently. A later write made while an older snapshot is being saved becomes a new generation and is queued for the next flush instead of being lost.

New config lives under `unsupported-settings`:
- `region-file-format`: `anvil` or `linear`, defaults to `anvil` so nothing changes unless you opt in
- `linear-compression-level`: defaults to `3`, since a high level costs real CPU on every whole-region flush
- `linear-flush-threads`: cross-region worker count, defaults to `2`, minimum `1`, restart required
- `linear-flush-interval-seconds`: batching interval, defaults to `5`, minimum `1`
- `linear-compression-threads`: optionally lets zstd parallelize a single region compression job
- `linear-region-cache-memory-budget-mb`: bounds estimated decompressed Linear-region cache memory independently of the normal region-count limit

Mod/Mixin compatibility: `LinearRegionFile` is a `RegionFile` subtype instead of replacing vanilla storage types with a new interface. `RegionFileStorage#regionCache` remains `Long2ObjectLinkedOpenHashMap<RegionFile>`, and `getRegionFile(ChunkPos)` retains its original `RegionFile` return descriptor, so descriptor-based Mixins keep matching. Format selection stays enum-driven and this PR adds no Mixins.

Implementation follows the original v1 spec (github.com/xymb-endcrystalme/LinearRegionFileFormatTools) byte for byte rather than improvising on it, so it should read what LinearReader already wrote without a conversion step.

**Before running this on a real world**: back it up first. Because a whole region is compressed as one stream, a corrupted/truncated `.linear` file loses every chunk in that region at once, unlike Anvil where a bad chunk only costs that one chunk.

Testing:
- `:youer:compileJava --rerun-tasks` and the follow-up incremental compile pass
- concurrency harness confirms two distinct region files flush concurrently
- the same region never exceeds one concurrent flush, including across multiple generations
- a 1 MiB foreground write completes while an older snapshot is deliberately blocked in compression
- persisted data reopens byte-identically after a later generation
- an injected flush failure propagates, remains dirty, and succeeds on retry
- previous bytecode inspection confirmed `getRegionFile(ChunkPos)RegionFile` is preserved

A real LinearReader-converted world and the reference `linear.py` tool have not yet been cross-checked; that should still be done before merging.