### PR TITLE
fix modded materials returning null after upstream stack-size change (issue #532)

### DIFF
--- a/src/main/java/com/mohistmc/youer/neoforge/NeoForgeInjectBukkit.java
+++ b/src/main/java/com/mohistmc/youer/neoforge/NeoForgeInjectBukkit.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import net.minecraft.core.Registry;
 import net.minecraft.core.particles.ParticleType;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -115,6 +116,7 @@ public class NeoForgeInjectBukkit {
     public static void addEnumMaterialsInBlocks() {
         var registry = BuiltInRegistries.BLOCK;
         List<String> materials = new ArrayList<>(Arrays.stream(Material.values())
+                .filter(Objects::nonNull)
                 .map(Enum::name)
                 .toList());
         for (Block block : registry) {

--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -2793,6 +2793,10 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
     private final Supplier<BlockType> blockType;
     public boolean isModBlock = false;
     public boolean isModItem = false;
+    // Youer start - stack size override for dynamically added (modded) materials.
+    // -1 means "not overridden"; getMaxStackSize() falls back to the item type in that case.
+    private int modMaxStackSize = -1;
+    // Youer end
 
     private Material(final int id) {
         this(id, MaterialData.class);
@@ -2801,6 +2805,17 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
     // Youer start - constructor used to set if the Material is a block or not
     private Material(final int id, boolean isForgeBlock, boolean isForgeItem) {
         this(id);
+        this.isModBlock = isForgeBlock;
+        this.isModItem = isForgeItem;
+    }
+
+    // Constructor matching MohistDynamEnum.addEnum(Material.class, ..., (int id, int stack,
+    // boolean isForgeBlock, boolean isForgeItem)). Added because NeoForgeInjectBukkit now
+    // passes the item's max stack size; without this signature the reflective enum-injection
+    // fails and addEnum returns null, leaving modded items/blocks unmapped.
+    private Material(final int id, int stack, boolean isForgeBlock, boolean isForgeItem) {
+        this(id);
+        this.modMaxStackSize = stack;
         this.isModBlock = isForgeBlock;
         this.isModItem = isForgeItem;
     }
@@ -2941,6 +2956,12 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
         if (this == LEGACY_AIR) {
             return 0;
         }
+        // Youer start - use the stack size captured at injection time for modded materials,
+        // whose ItemType may not resolve through the registry.
+        if (this.modMaxStackSize > 0) {
+            return this.modMaxStackSize;
+        }
+        // Youer end
         ItemType type = asItemType();
         return type == null ? 64 : type.getMaxStackSize();
     }
@@ -3802,6 +3823,7 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
                 material.isModBlock = true;
             } else {
                 material = MohistDynamEnum.addEnum(Material.class, materialName, List.of(Integer.TYPE, Integer.TYPE, Boolean.TYPE, Boolean.TYPE), List.of(id, stack, isBlock, isItem));
+                if(material == null) return null;
             }
             BY_NAME.put(materialName, material);
             material.key = CraftNamespacedKey.fromMinecraft(resourceLocation);
@@ -3809,6 +3831,7 @@ public enum Material implements Keyed, Translatable, net.kyori.adventure.transla
             return material;
         } else { // Forge Items
             Material material = MohistDynamEnum.addEnum(Material.class, materialName, List.of(Integer.TYPE, Integer.TYPE, Boolean.TYPE, Boolean.TYPE), List.of(id, stack, isBlock, isItem));
+            if(material == null) return null;
             BY_NAME.put(materialName, material);
             material.key = CraftNamespacedKey.fromMinecraft(resourceLocation);
             material.isModItem = true;

--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
@@ -168,11 +168,18 @@ public final class CraftMagicNumbers implements UnsafeValues {
     }
 
     public static Material getMaterial(Block block) {
-        return CraftMagicNumbers.BLOCK_MATERIAL.get(block);
+        Material material = CraftMagicNumbers.BLOCK_MATERIAL.get(block);
+        return material != null ? material : Material.AIR;
     }
 
     public static Material getMaterial(Item item) {
-        return CraftMagicNumbers.ITEM_MATERIAL.getOrDefault(item, Material.AIR);
+        // Note: modded items may be present in the map with a null value (see static
+        // initializer, where Material.getMaterial(<key>) returns null for unmapped mod
+        // items). getOrDefault only substitutes when the KEY is absent, not when the
+        // value is null, so guard against null explicitly to never hand callers a null
+        // Material (Bukkit/Paper and plugins assume ItemStack.getType() is non-null).
+        Material material = CraftMagicNumbers.ITEM_MATERIAL.get(item);
+        return material != null ? material : Material.AIR;
     }
 
     public static Item getItem(Material material) {


### PR DESCRIPTION
The last upstream update changed Material.addMaterial to pass an extra stack-size argument into MohistDynamEnum.addEnum, but no matching Material(int, int, boolean, boolean) constructor existed. The reflective enum injection could not resolve a constructor and returned null for every modded material, which cascaded into:
  
- null holes in Material.values(), crashing addEnumMaterialsInBlocks on startup
- modded items mapped to null in CraftMagicNumbers.ITEM_MATERIAL, so ItemStack.getType() returned null and NPE'd plugins on interact events
  
Changes:
- Material: add the missing (int id, int stack, boolean, boolean) constructor and a modMaxStackSize field; getMaxStackSize() now honors it for dynamically injected materials
- CraftMagicNumbers: getMaterial(Item)/getMaterial(Block) never return null, falling back to AIR
- NeoForgeInjectBukkit: filter nulls before mapping Material.values()
- Material.addMaterial: guard against a null result from addEnum